### PR TITLE
Add base-goerli L2 token address for cbEth

### DIFF
--- a/data/cbETH/data.json
+++ b/data/cbETH/data.json
@@ -17,6 +17,8 @@
     },
     "optimism-goerli": {
       "address": "0xd6909e9e702024eb93312B989ee46794c0fB1C9D"
+    },
+    "base-goerli": {
+      "address": "0x7c6b91D9Be155A6Db01f749217d76fF02A7227F2"
     }
-  }
 }


### PR DESCRIPTION
I am testing the asset listing process for Base by adding the token address for base-goerli.